### PR TITLE
fix typo

### DIFF
--- a/index.html
+++ b/index.html
@@ -386,7 +386,7 @@ iframe.contentWindow.dispatchEvent(event);</code></pre>
 		<h3 id="breaking_in_the_playlist">9.2 Breaking in the playlist</h3>
 		<p>To break in the playlist at the scheduled time, applications must support the ways to break as follows:</p>
 		<dl>
-			<dt>Hard beak</dt>
+			<dt>Hard break</dt>
 			<dd>
 				<p>When the scheduled time comes, applications must pause or stop then hide the current scene and show the scheduled scene even though the current scene is to be shown at the time.</p>
 			</dd>


### PR DESCRIPTION
correct 'beak' to 'break'
